### PR TITLE
Add support for 5 fixed vertical vane positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Changelog
+
+## [1.1.7] - Unreleased
+### Added
+- Added support for 5 fixed vertical vane positions: position1 to position5
+- Improved swing mode control to handle both swing motion and fixed positions
+
 ## [1.1.6] - 2024-11-11
 ### Fixed
 - Fixed connection test logic in configuration flow

--- a/custom_components/intesishome_local/manifest.json
+++ b/custom_components/intesishome_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/donfrensis/HA-intesishome-local/issues",
   "loggers": ["pyintesishome"],
   "requirements": ["pyintesishome==1.8.5"],
-  "version": "1.1.6"  
+  "version": "1.1.7"  
 }


### PR DESCRIPTION
## Description
Add support for controlling the vertical vanes with 5 fixed positions in addition to the existing swing modes.

### Changes
- Added VANE_POSITIONS mapping for fixed positions control
- Updated MAP_SWING_TO_IH to include position1 to position5
- Added fixed positions to swing_list options
- Enhanced swing_mode property to handle fixed positions
- Updated version to 1.1.7

### Type of change
- [ ] Bug fix 
- [x] New feature
- [ ] Breaking change
- [ ] Code improvements

### How Has This Been Tested?
Tested with local IntesisHome device using curl commands and Home Assistant interface.

### Checklist:
- [x] My code follows the style guidelines of the project
- [x] I have added appropriate documentation/comments
- [x] I have updated the CHANGELOG.md
- [x] I have updated the version in manifest.json